### PR TITLE
Using npm i instead of npm ci

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 ENV PATH /app/node_modules/.bin:$PATH
 
 COPY package.json ./
-RUN npm ci
+RUN npm i
 
 COPY . ./
 


### PR DESCRIPTION
It's better to use npm i on heroku (for some reason it's not recognizing the package-lock.json)